### PR TITLE
Handle the SocketExceptions in HandleCompletionStatus()

### DIFF
--- a/Source/AsyncIO/Windows/CompletionPort.cs
+++ b/Source/AsyncIO/Windows/CompletionPort.cs
@@ -170,17 +170,25 @@ namespace AsyncIO.Windows
                     // if the overlapped ntstatus is zero we assume success and don't call get overlapped result for optimization
                     if (overlapped.Success)
                     {
-                        if (overlapped.OperationType == OperationType.Accept)
+                        SocketError socketError = SocketError.Success;
+                        try
                         {
-                            overlapped.AsyncSocket.UpdateAccept();
+                            if (overlapped.OperationType == OperationType.Accept)
+                            {
+                                overlapped.AsyncSocket.UpdateAccept();
+                            }
+                            else if (overlapped.OperationType == OperationType.Connect)
+                            {
+                                overlapped.AsyncSocket.UpdateConnect();
+                            }
                         }
-                        else if (overlapped.OperationType == OperationType.Connect)
+                        catch (SocketException)
                         {
-                            overlapped.AsyncSocket.UpdateConnect();
+                            socketError = (SocketError)Marshal.GetLastWin32Error();
                         }
 
                         completionStatus = new CompletionStatus(overlapped.AsyncSocket, overlapped.State,
-                            overlapped.OperationType, SocketError.Success,
+                            overlapped.OperationType, socketError,
                             bytesTransferred);
                     }
                     else


### PR DESCRIPTION
Hi Doron,

yet another small change: I think, it would be better to deliver a CompletionStatus with the specific SocketError in case of socket exception, instead of letting the SocketException to bubble up. What do you think?