### PR TITLE
Relax netstandard platform requirement from netstandard 1.6 to netstandard 1.3

### DIFF
--- a/Source/AsyncIO.Tests/project.json
+++ b/Source/AsyncIO.Tests/project.json
@@ -4,7 +4,7 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "AsyncIO": "0.1.19.0",
+    "AsyncIO": "0.1.20.0",
     "dotnet-test-nunit": "3.4.0-beta-1",
     "NUnit": "3.4.1"
   },

--- a/Source/AsyncIO/AsyncSocket.cs
+++ b/Source/AsyncIO/AsyncSocket.cs
@@ -27,7 +27,7 @@ namespace AsyncIO
 
         public static AsyncSocket Create(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))                
 #else
             if (Environment.OSVersion.Platform != PlatformID.Win32NT || ForceDotNet.Forced)

--- a/Source/AsyncIO/CompletionPort.cs
+++ b/Source/AsyncIO/CompletionPort.cs
@@ -11,7 +11,7 @@ namespace AsyncIO
     {
         public static CompletionPort Create()
         {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 #else
             if (Environment.OSVersion.Platform != PlatformID.Win32NT || ForceDotNet.Forced)

--- a/Source/AsyncIO/SocketExtensions.cs
+++ b/Source/AsyncIO/SocketExtensions.cs
@@ -35,7 +35,7 @@ namespace AsyncIO
                 throw new ArgumentOutOfRangeException("port");
             }
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
             var ipAddress = Dns.GetHostAddressesAsync(host).Result.FirstOrDefault(ip=>                 
                 ip.AddressFamily == socket.AddressFamily || 
                 (socket.AddressFamily == AddressFamily.InterNetworkV6 && socket.DualMode && ip.AddressFamily == AddressFamily.InterNetwork));

--- a/Source/AsyncIO/Windows/CompletionPort.cs
+++ b/Source/AsyncIO/Windows/CompletionPort.cs
@@ -87,7 +87,7 @@ namespace AsyncIO.Windows
         {
             // Windows XP Has NO GetQueuedCompletionStatusEx
             // so we need dequeue IOPC one by one
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
             if (false)
             {
                 

--- a/Source/AsyncIO/Windows/Socket.cs
+++ b/Source/AsyncIO/Windows/Socket.cs
@@ -70,7 +70,7 @@ namespace AsyncIO.Windows
                 m_outOverlapped.Dispose();
 
                 // for Windows XP
-#if NETSTANDARD1_6
+#if NETSTANDARD1_3
                 UnsafeMethods.CancelIoEx(Handle, IntPtr.Zero);
 #else
                 if (Environment.OSVersion.Version.Major == 5)

--- a/Source/AsyncIO/project.json
+++ b/Source/AsyncIO/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.3": {
       "dependencies": {
         "NETStandard.Library": "1.6.0",
         "System.Net.NameResolution": "4.0.0"


### PR DESCRIPTION
This allows AsyncIO to be used across a greater number of platforms