### PR TITLE
Issue12

### DIFF
--- a/Source/AsyncIO/Windows/CompletionPort.cs
+++ b/Source/AsyncIO/Windows/CompletionPort.cs
@@ -220,16 +220,22 @@ namespace AsyncIO.Windows
                     {
                         SocketError socketError = SocketError.Success;
                         SocketFlags socketFlags;
-
-                        bool operationSucceed = UnsafeMethods.WSAGetOverlappedResult(overlapped.AsyncSocket.Handle,
-                            overlappedAddress,
-                            out bytesTransferred, false, out socketFlags);
-
-                        if (!operationSucceed)
+                        if(overlapped.Disposed)
                         {
-                            socketError = (SocketError)Marshal.GetLastWin32Error();
+                            socketError = SocketError.OperationAborted;
                         }
+                        else
+                        {
+                            bool operationSucceed = UnsafeMethods.WSAGetOverlappedResult(overlapped.AsyncSocket.Handle,
+                                overlappedAddress,
+                                out bytesTransferred, false, out socketFlags);
 
+                            if (!operationSucceed)
+                            {
+                                socketError = (SocketError)Marshal.GetLastWin32Error();
+                            }
+
+                        }
                         completionStatus = new CompletionStatus(overlapped.AsyncSocket, overlapped.State,
                             overlapped.OperationType, socketError,
                             bytesTransferred);

--- a/Source/AsyncIO/Windows/Overlapped.cs
+++ b/Source/AsyncIO/Windows/Overlapped.cs
@@ -72,6 +72,7 @@ namespace AsyncIO.Windows
         public void StartOperation(OperationType operationType)
         {
             InProgress = true;
+            Success = false;
             OperationType = operationType;
         }
 

--- a/Source/AsyncIO/Windows/Overlapped.cs
+++ b/Source/AsyncIO/Windows/Overlapped.cs
@@ -61,10 +61,7 @@ namespace AsyncIO.Windows
 
         public Windows.Socket AsyncSocket { get; private set; }
 
-        public bool Success
-        {
-            get { return Marshal.ReadIntPtr(m_address).Equals(IntPtr.Zero); }
-        }
+        public bool Success { get; private set; }
 
         public bool InProgress { get; private set; }
 
@@ -91,6 +88,11 @@ namespace AsyncIO.Windows
             if (overlapped.Disposed)
             {
                 overlapped.Free();
+                overlapped.Success = false;
+            }
+            else
+            {
+                overlapped.Success = Marshal.ReadIntPtr(overlapped.m_address).Equals(IntPtr.Zero);
             }
 
             return overlapped;          


### PR DESCRIPTION
In response to issue #12 

Modified Overlapped to handle closing of socket, which disposed the overlapped object while overlapped IO is still pending. Overlapped IO may return success or aborted depending on the timing of the CancelIoEx Call
see:
[CancelIoEx](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363792(v=vs.85).aspx)
