### PR TITLE
multitarget netstandard2.0

### DIFF
--- a/Source/AsyncIO/AsyncIO.csproj
+++ b/Source/AsyncIO/AsyncIO.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>0.1.42.0</Version>
-    <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>AsyncIO</AssemblyName>
     <AssemblyOriginatorKeyFile>./asyncio.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
hi,
this commit adds the compilation target for netstandard 2.0 as recommended by the dotnet team.
I got here tracking down compilation issues and nuget restore errors :
https://github.com/dotnet/project-system/issues/4252