### PR TITLE
License isn't published on NuGet

### DIFF
--- a/Source/AsyncIO/AsyncIO.csproj
+++ b/Source/AsyncIO/AsyncIO.csproj
@@ -22,6 +22,7 @@
     <PackageProjectUrl>https://github.com/somdoron/AsyncIO</PackageProjectUrl>
     <RepositoryUrl>https://github.com/somdoron/AsyncIO</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
+    <PackageLicenseExpression>MPL-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/Source/AsyncIO/AsyncIO.nuspec
+++ b/Source/AsyncIO/AsyncIO.nuspec
@@ -8,7 +8,7 @@
     <owners>$author$</owners>
 	<requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
-    <licenseUrl>https://www.mozilla.org/en-US/MPL/2.0/</licenseUrl>
+    <license type="expression">MPL-2.0</license>
     <projectUrl>https://github.com/somdoron/AsyncIO</projectUrl>
     <copyright>$copyright$</copyright>
   </metadata>


### PR DESCRIPTION
This PR will hopefully correct the issue of missing package metadata on NuGet, which causes static license analysis on the NuGet package to detect an unlicensed dependency.